### PR TITLE
Fix Lombok property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,11 +9,15 @@
     <artifactId>framework-cognito-provider</artifactId>
     <version>1.2.1-SNAPSHOT</version>
 
-    <parent>
+  <parent>
       <groupId>com.end2endlogic</groupId>
       <artifactId>quantum-parent</artifactId>
       <version>1.2.1-SNAPSHOT</version>
-    </parent>
+  </parent>
+
+  <properties>
+      <lombok.version>1.18.32</lombok.version>
+  </properties>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>The cognito provider for the quantum framework</description>
@@ -96,7 +100,7 @@
                         <path>
                             <groupId>org.projectlombok</groupId>
                             <artifactId>lombok</artifactId>
-                            <version>${lombrok.version}</version>
+                            <version>${lombok.version}</version>
                         </path>
                         <path>
                             <groupId>io.quarkus</groupId>


### PR DESCRIPTION
## Summary
- fix typo in Lombok version property
- define `lombok.version` locally

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_688c11f12678832681f1f1cfb2a511c1